### PR TITLE
Fix pkg-config dependencies for Qt5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,10 @@ if( NOT BUILD_WITH_QT4 )
             qt5_wrap_cpp(${ARGN})
         endmacro()
     endif()
+
+    # pkg-config names of QtCore and QtNetwork are Qt5Core and Qt5Network for
+    # Qt5
+    set(ECHONEST_QT_MAJOR_VERSION "5")
 endif()
 
 if( NOT Qt5Core_DIR )
@@ -32,6 +36,8 @@ if( NOT Qt5Core_DIR )
     macro(qt_wrap_cpp)
         qt4_wrap_cpp(${ARGN})
     endmacro()
+
+    set(ECHONEST_QT_MAJOR_VERSION "")
 endif()
 
 find_package(QJSON REQUIRED)

--- a/libechonest.pc.in
+++ b/libechonest.pc.in
@@ -6,6 +6,6 @@ includedir=@INCLUDE_INSTALL_DIR@
 Name: libechonest
 Description: libechonest is a qt-based library that makes the Echo Nest APIs easily accessible
 Version: @ECHONEST_LIB_MAJOR_VERSION@.@ECHONEST_LIB_MINOR_VERSION@.@ECHONEST_LIB_PATCH_VERSION@
-Requires: QtCore QtNetwork
+Requires: Qt@ECHONEST_QT_MAJOR_VERSION@Core Qt@ECHONEST_QT_MAJOR_VERSION@Network
 Libs: -L${libdir} -lechonest
 Cflags: -I${includedir}


### PR DESCRIPTION
For Qt5, these have the major version in their name, e.g. Qt5Core
